### PR TITLE
Fix graphical glitches and segmentation fault in image viewer.

### DIFF
--- a/src/dui/outputs_n_viewers/img_view_tools.py
+++ b/src/dui/outputs_n_viewers/img_view_tools.py
@@ -324,5 +324,9 @@ class build_qimg:
             np.size(arr_i[:, 0:1, 0:1]),
             QImage.Format_RGB32,
         )
+        # The data buffer must remain valid throughout the life of the QImage.
+        # A simple way to do this is to assign the NumPy array as an attribute
+        # of the QImage.
+        q_img.array = arr_i
 
         return q_img


### PR DESCRIPTION
It seems to me that `img_w_cpp` and `build_qimg` are essentially pseudoclasses. Graphical errors and occasional segfaults were occurring, probably when the data buffer `arr_i.data` went out of scope and was garbage-collected.

It might be possible to remove these classes and adopt a more functional approach that could tidy this up. But for now, simply keeping the data array around seems to fix the issue.