### PR TITLE
Simplify ProgBarBox

### DIFF
--- a/src/dui/outputs_n_viewers/img_view_tools.py
+++ b/src/dui/outputs_n_viewers/img_view_tools.py
@@ -48,6 +48,7 @@ class ProgBarBox(QProgressDialog):
         self.setWindowTitle("Updating GUI data")
         self.setWindowModality(Qt.WindowModal)
         self.setMinimumDuration(100)
+        self.setCancelButton(None)
 
     def __call__(self, updated_val):
 

--- a/src/dui/outputs_n_viewers/img_view_tools.py
+++ b/src/dui/outputs_n_viewers/img_view_tools.py
@@ -33,27 +33,25 @@ logger = logging.getLogger(__name__)
 
 class ProgBarBox(QProgressDialog):
     def __init__(self, max_val=100, min_val=0, text="Working"):
-        super().__init__(parent=None)
-        self.setMinimumDuration(50)
 
-        if max_val > min_val:
-            self.my_max = max_val
-            self.my_min = min_val
+        if max_val <= min_val:
+            raise ValueError("max_val must be larger than min_val")
 
-        self.my_delta = max_val - min_val
-        self.my_txt = text
+        super().__init__(
+            labelText=text,
+            cancelButtonText="",
+            minimum=min_val,
+            maximum=max_val,
+            parent=None)
 
-        self.setLabelText(text)
-        self.setWindowTitle("updating GUI data")
-        self.setCancelButtonText("")
+        self.setValue(min_val)
+        self.setWindowTitle("Updating GUI data")
         self.setWindowModality(Qt.WindowModal)
-        self.setValue(200)
-        self.show()
+        self.setMinimumDuration(100)
 
     def __call__(self, updated_val):
-        prog_psent = float(updated_val - self.my_min) / self.my_delta
-        # sys.stdout.write('\r' + self.my_txt + " " + str(prog_psent))
-        self.setValue(prog_psent * 100)
+
+        self.setValue(updated_val)
 
     def ended(self):
         self.setValue(100)


### PR DESCRIPTION
It seemed to me that `ProgBarBox` was doing a lot of extra unnecessary work. Also, with a minimum duration of just 50 ms it would appear even for very fast tasks before disappearing as a flash. This PR makes `ProgBarBox` into a very thin wrapper around a standard `QProgressDialog`.