### PR TITLE
Disable external viewer buttons until data are available.

### DIFF
--- a/src/dui/error_loading_dialog.py
+++ b/src/dui/error_loading_dialog.py
@@ -48,19 +48,32 @@ class Ui_LoadErrorDialog(object):
 
         self.verticalLayout.addWidget(self.buttonBox)
 
-
         self.gridLayout.addLayout(self.verticalLayout, 0, 0, 1, 1)
-
 
         self.retranslateUi(LoadErrorDialog)
         self.buttonBox.rejected.connect(LoadErrorDialog.close)
 
         QMetaObject.connectSlotsByName(LoadErrorDialog)
+
     # setupUi
 
     def retranslateUi(self, LoadErrorDialog):
-        LoadErrorDialog.setWindowTitle(QCoreApplication.translate("LoadErrorDialog", u"Error loading DUI", None))
-        self.label.setText(QCoreApplication.translate("LoadErrorDialog", u"An unexpected error occured whilst loading your previous DUI workspace:", None))
-        self.label_2.setText(QCoreApplication.translate("LoadErrorDialog", u"<html><head/><body><p>Please report this error to <a href=\"mailto:dials-support@lists.sourceforge.net\"><span style=\" text-decoration: underline; color:#0000ff;\">dials-support@lists.sourceforge.net</span></a>.</p><p>Please move or remove the <tt>dui-files/</tt> subfolder or change your working directory to continue.</p></body></html>", None))
-    # retranslateUi
+        LoadErrorDialog.setWindowTitle(
+            QCoreApplication.translate("LoadErrorDialog", u"Error loading DUI", None)
+        )
+        self.label.setText(
+            QCoreApplication.translate(
+                "LoadErrorDialog",
+                u"An unexpected error occured whilst loading your previous DUI workspace:",
+                None,
+            )
+        )
+        self.label_2.setText(
+            QCoreApplication.translate(
+                "LoadErrorDialog",
+                u'<html><head/><body><p>Please report this error to <a href="mailto:dials-support@lists.sourceforge.net"><span style=" text-decoration: underline; color:#0000ff;">dials-support@lists.sourceforge.net</span></a>.</p><p>Please move or remove the <tt>dui-files/</tt> subfolder or change your working directory to continue.</p></body></html>',
+                None,
+            )
+        )
 
+    # retranslateUi

--- a/src/dui/gui_utils.py
+++ b/src/dui/gui_utils.py
@@ -723,13 +723,15 @@ class OuterCaller(QWidget):
 
         v_box = QVBoxLayout()
 
-        recip_lat_but = QPushButton("\n Open reciprocal lattice viewer \n")
-        recip_lat_but.clicked.connect(self.run_recip_dialg)
-        v_box.addWidget(recip_lat_but)
+        self.recip_lat_but = QPushButton("\n Open reciprocal lattice viewer \n")
+        self.recip_lat_but.clicked.connect(self.run_recip_dialg)
+        self.recip_lat_but.setEnabled(False)
+        v_box.addWidget(self.recip_lat_but)
 
-        img_but = QPushButton("\n Open image viewer \n")
-        img_but.clicked.connect(self.run_img_dialg)
-        v_box.addWidget(img_but)
+        self.img_but = QPushButton("\n Open image viewer \n")
+        self.img_but.clicked.connect(self.run_img_dialg)
+        self.img_but.setEnabled(False)
+        v_box.addWidget(self.img_but)
 
         self.diag = ExternalProcDialog(parent=self.window())
         self.setLayout(v_box)
@@ -738,6 +740,11 @@ class OuterCaller(QWidget):
     def update_data(self, new_pick=None, new_json=None):
         self.my_pick = new_pick
         self.my_json = new_json
+
+        if new_json and os.path.exists(new_json):
+            self.img_but.setEnabled(True)
+            if new_pick[0] and os.path.exists(new_pick[0]):
+                self.recip_lat_but.setEnabled(True)
 
     def run_recip_dialg(self):
         self.diag.run_my_proc(
@@ -852,7 +859,7 @@ def loading_error_dialog(message):
     # from dui.resources.error_loading_dialog import Ui_LoadErrorDialog
 
     dialog_filename = get_package_path("resources/error_loading_dialog.ui")
-    #Ui_LoadErrorDialog, _ = loadUiType(dialog_filename)
+    # Ui_LoadErrorDialog, _ = loadUiType(dialog_filename)
     # Use compiled class while pyside2-uic is broken in CCP4
     from .error_loading_dialog import Ui_LoadErrorDialog
 

--- a/src/dui/outputs_n_viewers/img_view_tools.py
+++ b/src/dui/outputs_n_viewers/img_view_tools.py
@@ -42,7 +42,8 @@ class ProgBarBox(QProgressDialog):
             cancelButtonText="",
             minimum=min_val,
             maximum=max_val,
-            parent=None)
+            parent=None,
+        )
 
         self.setValue(min_val)
         self.setWindowTitle("Updating GUI data")


### PR DESCRIPTION
Fixes #83. Not ready, because I want to fix #51 as well, and this is proving more difficult.