### PR TITLE
Remove nproc handling. Fixes #172

### DIFF
--- a/src/dui/custom_widgets.py
+++ b/src/dui/custom_widgets.py
@@ -774,27 +774,6 @@ class ParamMainWidget(QWidget):
 
         self.update_command_lst_low_level.emit(self.command_lst[0])
 
-        try:
-            max_nproc = self.simpler_widget.set_max_nproc()
-            if max_nproc > 1:
-                self.raise_nproc_str = (
-                    str(self.simpler_widget.box_nproc.local_path) + "=" + str(max_nproc)
-                )
-                QTimer.singleShot(1000, self.raise_nproc_to_max)
-
-        except AttributeError:
-            pass
-
-    def raise_nproc_to_max(self):
-        found_nproc = False
-        for single_par in self.command_lst[0]:
-            if "mp.nproc" in single_par:
-                found_nproc = True
-
-        if not found_nproc:
-            self.command_lst[0].append(self.raise_nproc_str)
-            self.update_command_lst_low_level.emit(self.command_lst[0])
-
     def update_advanced_widget(self, str_path, str_value):
 
         for bg_widg in (

--- a/src/dui/simpler_param_widgets.py
+++ b/src/dui/simpler_param_widgets.py
@@ -183,19 +183,6 @@ class FindspotsSimplerParameterTab(SimpleParamTab):
         xds_global_threshold_hb.addWidget(xds_global_threshold_spn_bx)
         localLayout.addLayout(xds_global_threshold_hb)
 
-        hbox_lay_nproc = QHBoxLayout()
-        label_nproc = QLabel("Number of jobs")
-        # label_nproc.setPalette(palette_object)
-        # label_nproc.setFont( QFont("Monospace", 10))
-        hbox_lay_nproc.addWidget(label_nproc)
-
-        self.box_nproc = QSpinBox()
-        self.box_nproc.local_path = "spotfinder.mp.nproc"
-
-        self.box_nproc.editingFinished.connect(self.spnbox_finished)
-        hbox_lay_nproc.addWidget(self.box_nproc)
-        localLayout.addLayout(hbox_lay_nproc)
-
         self.inner_reset_btn = ResetButton()
         localLayout.addWidget(self.inner_reset_btn)
         localLayout.addStretch()
@@ -203,11 +190,6 @@ class FindspotsSimplerParameterTab(SimpleParamTab):
         self.setLayout(localLayout)
 
         self.lst_var_widg = _get_all_direct_layout_widget_children(localLayout)
-
-    def set_max_nproc(self):
-        cpu_max_proc = int(libtbx.introspection.number_of_processors())
-        self.box_nproc.setValue(cpu_max_proc)
-        return cpu_max_proc
 
 
 class IndexSimplerParamTab(SimpleParamTab):
@@ -435,31 +417,14 @@ class IntegrateSimplerParamTab(SimpleParamTab):
         d_min_spn_bx.editingFinished.connect(self.spnbox_finished)
         localLayout.addLayout(hbox_d_min)
 
-        hbox_lay_nproc = QHBoxLayout()
-        label_nproc = QLabel("Number of jobs")
-        # label_nproc.setFont( QFont("Monospace", 10))
-        hbox_lay_nproc.addWidget(label_nproc)
-
-        self.box_nproc = QSpinBox()
-
-        self.box_nproc.local_path = "integration.mp.nproc"
-        self.box_nproc.editingFinished.connect(self.spnbox_finished)
-        hbox_lay_nproc.addWidget(self.box_nproc)
-        localLayout.addLayout(hbox_lay_nproc)
-
         self.inner_reset_btn = ResetButton()
         localLayout.addWidget(self.inner_reset_btn)
         localLayout.addStretch()
 
         self.setLayout(localLayout)
-        self.box_nproc.tmp_lst = None
 
         self.lst_var_widg = _get_all_direct_layout_widget_children(localLayout)
 
-    def set_max_nproc(self):
-        cpu_max_proc = int(libtbx.introspection.number_of_processors())
-        self.box_nproc.setValue(cpu_max_proc)
-        return cpu_max_proc
 
 
 class SymmetrySimplerParamTab(SimpleParamTab):


### PR DESCRIPTION
Jumped the gun on this it seems. CCP4 8.0 test builds are on `DIALS 3.2.3-gcbf1028a5-release` and don't have the [`nproc=auto`](https://github.com/dials/dials/issues/1408) handling yet.