### PR TITLE
Export merged

### DIFF
--- a/src/dui/cli_utils.py
+++ b/src/dui/cli_utils.py
@@ -331,7 +331,7 @@ def build_command_lst(node_obj, cmd_lst):
             output_str = "output.json=" + node_obj.json_sym_out
             lst_inner.append(output_str)
 
-    elif cmd_lst_ini == "export":
+    elif cmd_lst_ini in ("export", "merge"):
         lst_inner.append(node_obj.prev_step.json_file_out)
         lst_inner.append(node_obj.prev_step.refl_pickle_file_out)
         node_obj.log_file_out = str(node_obj.lin_num) + "_" + cmd_lst_ini + ".log"

--- a/src/dui/custom_widgets.py
+++ b/src/dui/custom_widgets.py
@@ -270,6 +270,7 @@ class ExportPage(QWidget):
         step_label.setFont(label_font)
 
         self.check_scale = QCheckBox("Output scaled intensities")
+        self.check_scale.setEnabled(False)
         self.check_scale.setChecked(False)
         self.check_scale.stateChanged.connect(self.update_command)
 
@@ -278,9 +279,14 @@ class ExportPage(QWidget):
         self.check_merge.setEnabled(False)
         self.check_merge.stateChanged.connect(self.update_command)
 
-        out_file_label = QLabel("mtz output name:")
+        # File selection launcher
+        self.save_file_btn = QPushButton("Select output file")
+        self.save_file_btn.setIconSize(QSize(80, 48))
+        self.save_file_btn.clicked.connect(self.select_file)
 
-        self.simple_lin = QLineEdit(self)
+        out_file_label = QLabel("mtz output name:")
+        self.dui_files_dir = os.path.join(sys_arg.directory, "dui_files")
+        self.simple_lin = QLineEdit(self, readOnly=True)
         self.simple_lin.textChanged.connect(self.update_command)
 
         self.warning_label = QLabel(" ")
@@ -289,6 +295,7 @@ class ExportPage(QWidget):
         main_v_box.addWidget(step_label)
         main_v_box.addWidget(self.check_scale)
         main_v_box.addWidget(self.check_merge)
+        main_v_box.addWidget(self.save_file_btn)
         main_v_box.addWidget(out_file_label)
         main_v_box.addWidget(self.simple_lin)
         main_v_box.addStretch()
@@ -298,7 +305,16 @@ class ExportPage(QWidget):
         self.fist_time = False
         # self.show()
 
-        self.simple_lin.setText("integrated.mtz")
+        self.simple_lin.setText(os.path.join(self.dui_files_dir,"integrated.mtz"))
+
+    def select_file(self):
+        filter = "MTZ Files (*.mtz)"
+        file_path, _ = QFileDialog.getSaveFileName(
+            self, "Select file", os.path.join(sys_arg.directory, "dui_files"), "MTZ Files (*.mtz)"
+        )
+        if not file_path.lower().endswith(".mtz"):
+            file_path += ".mtz"
+        self.simple_lin.setText(file_path)
 
     def update_command(self):
         param1_com = str(self.simple_lin.text())
@@ -312,7 +328,7 @@ class ExportPage(QWidget):
                 param2_com = "intensity=scale"
                 self.command_lst[0].append(param2_com)
 
-        # Enable/disable the merge button according to selection of scaled
+        # Enable/disable the merge check according to selection of scaled
         if self.check_scale.checkState():
             self.check_merge.setEnabled(True)
         else:
@@ -348,7 +364,6 @@ class ExportPage(QWidget):
 
     def activate_me(self, cur_nod=None):
         self.simple_lin.setEnabled(True)
-        self.check_scale.setEnabled(True)
         if self.fist_time is False:
             self.fist_time = True
             self.simple_lin.setText("integrated.mtz")
@@ -370,8 +385,9 @@ class ExportPage(QWidget):
                 my_node = my_node.prev_step
 
             if found_scale is True:
-                self.simple_lin.setText("scaled.mtz")
+                self.simple_lin.setText(os.path.join(self.dui_files_dir,"scaled.mtz"))
                 self.check_scale.setChecked(True)
+                self.check_scale.setEnabled(True)
                 self.check_merge.setEnabled(True)
 
         self.check_repeated_file()

--- a/src/dui/custom_widgets.py
+++ b/src/dui/custom_widgets.py
@@ -280,7 +280,7 @@ class ExportPage(QWidget):
         self.check_merge.stateChanged.connect(self.update_command)
 
         # File selection launcher
-        self.save_file_btn = QPushButton("Select output file")
+        self.save_file_btn = QPushButton("Change output file")
         self.save_file_btn.setIconSize(QSize(80, 48))
         self.save_file_btn.clicked.connect(self.select_file)
 
@@ -305,7 +305,7 @@ class ExportPage(QWidget):
         self.fist_time = False
         # self.show()
 
-        self.simple_lin.setText(os.path.join(self.dui_files_dir, "integrated.mtz"))
+        self.simple_lin.setText(os.path.join(self.dui_files_dir, "dui_output.mtz"))
 
     def select_file(self):
         file_path, _ = QFileDialog.getSaveFileName(
@@ -314,6 +314,8 @@ class ExportPage(QWidget):
             os.path.join(sys_arg.directory, "dui_files"),
             "MTZ Files (*.mtz)",
         )
+        if file_path.strip() == "":
+            file_path = "dui_output.mtz"
         if not file_path.lower().endswith(".mtz"):
             file_path += ".mtz"
         self.simple_lin.setText(file_path)
@@ -368,7 +370,7 @@ class ExportPage(QWidget):
         self.simple_lin.setEnabled(True)
         if self.fist_time is False:
             self.fist_time = True
-            self.simple_lin.setText("integrated.mtz")
+            self.simple_lin.setText("dui_output.mtz")
             self.check_scale.setChecked(False)
             self.check_merge.setChecked(False)
             self.check_merge.setEnabled(False)
@@ -387,7 +389,6 @@ class ExportPage(QWidget):
                 my_node = my_node.prev_step
 
             if found_scale is True:
-                self.simple_lin.setText(os.path.join(self.dui_files_dir, "scaled.mtz"))
                 self.check_scale.setChecked(True)
                 self.check_scale.setEnabled(True)
                 self.check_merge.setEnabled(True)

--- a/src/dui/custom_widgets.py
+++ b/src/dui/custom_widgets.py
@@ -343,7 +343,7 @@ class ExportPage(QWidget):
         cwd_path = os.path.join(sys_arg.directory, "dui_files")
         mtz_file_path = os.path.join(cwd_path, param1_com)
         if os.path.isfile(mtz_file_path):
-            txt_warning = "Warning, file: " + param1_com + " already exists"
+            txt_warning = "Warning, output file already exists and will be overwritten"
             self.warning_label.setText(txt_warning)
             self.warning_label.setStyleSheet("color: rgba(255, 55, 55, 255)")
             """

--- a/src/dui/custom_widgets.py
+++ b/src/dui/custom_widgets.py
@@ -269,22 +269,28 @@ class ExportPage(QWidget):
         step_label = QLabel("Export")
         step_label.setFont(label_font)
 
+        self.check_scale = QCheckBox("Output scaled intensities")
+        self.check_scale.setChecked(False)
+        self.check_scale.stateChanged.connect(self.update_command)
+
+        self.check_merge = QCheckBox("Output merged reflections")
+        self.check_merge.setChecked(False)
+        self.check_merge.setEnabled(False)
+        self.check_merge.stateChanged.connect(self.update_command)
+
         out_file_label = QLabel("mtz output name:")
 
         self.simple_lin = QLineEdit(self)
         self.simple_lin.textChanged.connect(self.update_command)
 
-        self.check_scale = QCheckBox("Output Scaled Intensities")
-        self.check_scale.setChecked(False)
-        self.check_scale.stateChanged.connect(self.update_command)
-
         self.warning_label = QLabel(" ")
         self.warning_label.setWordWrap(True)
 
         main_v_box.addWidget(step_label)
+        main_v_box.addWidget(self.check_scale)
+        main_v_box.addWidget(self.check_merge)
         main_v_box.addWidget(out_file_label)
         main_v_box.addWidget(self.simple_lin)
-        main_v_box.addWidget(self.check_scale)
         main_v_box.addStretch()
         main_v_box.addWidget(self.warning_label)
         main_v_box.addStretch()
@@ -303,6 +309,11 @@ class ExportPage(QWidget):
         if self.check_scale.checkState():
             param2_com = "intensity=scale"
             self.command_lst[0].append(param2_com)
+            self.check_merge.setEnabled(True)
+        else:
+            print("checkState false")
+            self.check_merge.setChecked(False)
+            self.check_merge.setEnabled(False)
 
         self.update_command_lst_low_level.emit(self.command_lst[0])
         self.check_repeated_file()
@@ -327,6 +338,7 @@ class ExportPage(QWidget):
     def gray_me_out(self):
         self.simple_lin.setEnabled(False)
         self.check_scale.setEnabled(False)
+        self.check_merge.setEnabled(False)
 
         self.fist_time = False
 
@@ -337,6 +349,9 @@ class ExportPage(QWidget):
             self.fist_time = True
             self.simple_lin.setText("integrated.mtz")
             self.check_scale.setChecked(False)
+            self.check_merge.setChecked(False)
+            self.check_merge.setEnabled(False)
+
             my_node = cur_nod
             found_scale = False
             for iters in range(5):
@@ -353,6 +368,7 @@ class ExportPage(QWidget):
             if found_scale is True:
                 self.simple_lin.setText("scaled.mtz")
                 self.check_scale.setChecked(True)
+                self.check_merge.setEnabled(True)
 
         self.check_repeated_file()
 

--- a/src/dui/custom_widgets.py
+++ b/src/dui/custom_widgets.py
@@ -284,7 +284,7 @@ class ExportPage(QWidget):
         self.save_file_btn.setIconSize(QSize(80, 48))
         self.save_file_btn.clicked.connect(self.select_file)
 
-        out_file_label = QLabel("mtz output name:")
+        out_file_label = QLabel("MTZ file to write:")
         self.dui_files_dir = os.path.join(sys_arg.directory, "dui_files")
         self.simple_lin = QLineEdit(self, readOnly=True)
         self.simple_lin.textChanged.connect(self.update_command)
@@ -305,12 +305,14 @@ class ExportPage(QWidget):
         self.fist_time = False
         # self.show()
 
-        self.simple_lin.setText(os.path.join(self.dui_files_dir,"integrated.mtz"))
+        self.simple_lin.setText(os.path.join(self.dui_files_dir, "integrated.mtz"))
 
     def select_file(self):
-        filter = "MTZ Files (*.mtz)"
         file_path, _ = QFileDialog.getSaveFileName(
-            self, "Select file", os.path.join(sys_arg.directory, "dui_files"), "MTZ Files (*.mtz)"
+            self,
+            "Select file",
+            os.path.join(sys_arg.directory, "dui_files"),
+            "MTZ Files (*.mtz)",
         )
         if not file_path.lower().endswith(".mtz"):
             file_path += ".mtz"
@@ -385,7 +387,7 @@ class ExportPage(QWidget):
                 my_node = my_node.prev_step
 
             if found_scale is True:
-                self.simple_lin.setText(os.path.join(self.dui_files_dir,"scaled.mtz"))
+                self.simple_lin.setText(os.path.join(self.dui_files_dir, "scaled.mtz"))
                 self.check_scale.setChecked(True)
                 self.check_scale.setEnabled(True)
                 self.check_merge.setEnabled(True)

--- a/src/dui/custom_widgets.py
+++ b/src/dui/custom_widgets.py
@@ -255,7 +255,7 @@ class ExportPage(QWidget):
     """
     This stacked widget basically helps the user to export by
     generating an MTZ file, there is no auto-generated GUI
-    form Phil parameters in use withing this widget.
+    form Phil parameters in use within this widget.
     """
 
     def __init__(self, parent=None):
@@ -301,17 +301,21 @@ class ExportPage(QWidget):
         self.simple_lin.setText("integrated.mtz")
 
     def update_command(self):
-        self.command_lst = [["export"]]
-
         param1_com = str(self.simple_lin.text())
-        self.command_lst[0].append("mtz.hklout=" + param1_com)
 
+        if self.check_merge.checkState():
+            self.command_lst = [["merge", "output.mtz=" + param1_com]]
+        else:
+            self.command_lst = [["export", "mtz.hklout=" + param1_com]]
+
+            if self.check_scale.checkState():
+                param2_com = "intensity=scale"
+                self.command_lst[0].append(param2_com)
+
+        # Enable/disable the merge button according to selection of scaled
         if self.check_scale.checkState():
-            param2_com = "intensity=scale"
-            self.command_lst[0].append(param2_com)
             self.check_merge.setEnabled(True)
         else:
-            print("checkState false")
             self.check_merge.setChecked(False)
             self.check_merge.setEnabled(False)
 

--- a/src/dui/gui_utils.py
+++ b/src/dui/gui_utils.py
@@ -164,8 +164,8 @@ def try_move_last_info(export_node, gui2_log):
         mtz_name_from = "integrated.mtz"
         for parm in export_node.ll_command_lst[0]:
             logger.info(parm)
-            if "mtz.hklout=" in parm:
-                mtz_name_from = parm[11:]
+            if parm.startswith("mtz.hklout=") or parm.startswith("output.mtz="):
+                mtz_name_from = parm.split("=")[1]
 
         mtz_name_from = os.path.join(cwd_path, mtz_name_from)
         mtz_name_to = os.path.join(sys_arg.directory, "integrated.mtz")

--- a/src/dui/gui_utils.py
+++ b/src/dui/gui_utils.py
@@ -148,55 +148,44 @@ ACTIONS = OrderedDict(
 )
 
 
-def try_move_last_info(export_node, gui2_log):
-    logger.debug(
-        "\n JUST exported MOVING start ... \n ______________________________________________________"
-    )
+def update_manifest(export_node):
+    """Update or create manifest.json, which contains information about exported
+    MTZ files for use by calling software such as ccp4i2 and CCP4 Cloud"""
 
-    cwd_path = os.path.join(sys_arg.directory, "dui_files")
-    report_out = generate_report(export_node.prev_step)
+    manifest_path = os.path.join(sys_arg.directory, "manifest.json")
 
-    try:
-        prev_step_rept_from = os.path.join(cwd_path, report_out)
-        # prev_step_rept_to = os.path.join(sys_arg.directory, export_node.prev_step.report_out)
-        prev_step_rept_to = os.path.join(sys_arg.directory, "dui_report.html")
+    # Read or set up the manifest dictionary
+    if os.path.exists(manifest_path):
+        try:
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+        except json.decoder.JSONDecodeError:
+            pass
+    else:
+        manifest = {}
 
-        mtz_name_from = "integrated.mtz"
-        for parm in export_node.ll_command_lst[0]:
-            logger.info(parm)
-            if parm.startswith("mtz.hklout=") or parm.startswith("output.mtz="):
-                mtz_name_from = parm.split("=")[1]
+    # Identify the MTZ file and type
+    mtz_path = None
+    mtz_type = "integrated"
+    for parm in export_node.ll_command_lst[0]:
+        logger.info(parm)
+        if parm.startswith("mtz.hklout=") or parm.startswith("output.mtz="):
+            mtz_path = os.path.realpath(parm.split("=")[1])
+        elif parm == "intensity=scale":
+            mtz_type = "scaled"
+    if export_node.ll_command_lst[0][0] == "merge":
+        mtz_type = "merged"
 
-        mtz_name_from = os.path.join(cwd_path, mtz_name_from)
-        mtz_name_to = os.path.join(sys_arg.directory, "integrated.mtz")
+    # Get a path for the DIALS report for the previous step (if it already
+    # exists this will return the existing path)
+    report_out = os.path.realpath(generate_report(export_node.prev_step))
 
-        gui2_log["last_HTML_report"] = prev_step_rept_from
-        gui2_log["last_MTZ"] = mtz_name_from
+    # Add to the manifest and write it out
+    manifest[mtz_path] = {"type": mtz_type, "report": report_out}
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=4)
 
-        for pair in gui2_log["pairs_list"]:
-            if pair[1] == mtz_name_from:
-                logger.info("\nfound same name \n")
-                gui2_log["pairs_list"].remove(pair)
-
-        gui2_log["pairs_list"].append((prev_step_rept_from, mtz_name_from))
-
-        shutil.copy(mtz_name_from, mtz_name_to)
-        shutil.copy(prev_step_rept_from, prev_step_rept_to)
-
-        gui2_log_path = os.path.join(cwd_path, "output.json")
-
-        # logger.info(f"Writing: {gui2_log_path}")
-
-        with open(gui2_log_path, "w") as fp:
-            json.dump(gui2_log, fp, indent=4)
-
-        # logger.info(f"\n ___________________ gui2_log: {gui2_log}")
-
-    except OSError:
-        logger.info("ERROR: mtz file not there")
-        logger.debug("IOError on try_move_last_info(gui_utils)")
-
-    return gui2_log
+    return
 
 
 def try_find_prev_mask_pickle(cur_nod):

--- a/src/dui/gui_utils.py
+++ b/src/dui/gui_utils.py
@@ -152,7 +152,7 @@ def update_manifest(export_node):
     """Update or create manifest.json, which contains information about exported
     MTZ files for use by calling software such as ccp4i2 and CCP4 Cloud"""
 
-    manifest_path = os.path.join(sys_arg.directory, "manifest.json")
+    manifest_path = os.path.join(sys_arg.directory, "dui_files", "manifest.json")
 
     # Read or set up the manifest dictionary
     if os.path.exists(manifest_path):

--- a/src/dui/m_idials.py
+++ b/src/dui/m_idials.py
@@ -55,6 +55,7 @@ class CommandNode:
         "symmetry",
         "scale",
         "export",
+        "merge",
         "generate_mask",
         "modify_geometry",
     ]
@@ -93,7 +94,7 @@ class CommandNode:
                 self.success = self.dials_command(
                     lst_cmd_to_run=self.cmd_lst_to_run, ref_to_class=ref_to_class
                 )
-                # For cases where the run command does not write it's own log
+                # For cases where the run command does not write its own log
                 # file, we need to create one - so there is something to
                 # display. This includes: Reindex, generate_mask - see
                 # generated list in cli_utils.build_command_lst

--- a/src/dui/m_idials_gui.py
+++ b/src/dui/m_idials_gui.py
@@ -603,7 +603,10 @@ class MainWidget(QMainWindow):
             my_widget.activate_me(cur_nod=self.idials_runner.current_node)
 
         else:
-            if self.idials_runner.current_node.ll_command_lst[0][0] not in ("export", "merge"):
+            if self.idials_runner.current_node.ll_command_lst[0][0] not in (
+                "export",
+                "merge",
+            ):
                 self.stop_run_retry.repeat_btn.setEnabled(True)
 
             my_widget.gray_me_out()
@@ -795,7 +798,10 @@ class MainWidget(QMainWindow):
             # Supress opening of the reindex popup next time
             self.just_reindexed = True
 
-        elif tmp_curr.ll_command_lst[0][0] in ("export", "merge") and tmp_curr.success is True:
+        elif (
+            tmp_curr.ll_command_lst[0][0] in ("export", "merge")
+            and tmp_curr.success is True
+        ):
             self.gui2_log = try_move_last_info(tmp_curr, self.gui2_log)
 
         self.check_reindex_pop()

--- a/src/dui/m_idials_gui.py
+++ b/src/dui/m_idials_gui.py
@@ -43,7 +43,7 @@ from .gui_utils import (
     get_main_path,
     kill_w_child,
     try_find_prev_mask_pickle,
-    try_move_last_info,
+    update_manifest,
     update_info,
     update_pbar_msg,
 )
@@ -434,8 +434,6 @@ class MainWidget(QMainWindow):
             self.idials_runner = Runner()
             self.cli_tree_output(self.idials_runner)
 
-        self.gui2_log = {"pairs_list": []}
-
         self.cur_html = None
         self.cur_pick = None
         self.cur_json = None
@@ -802,7 +800,7 @@ class MainWidget(QMainWindow):
             tmp_curr.ll_command_lst[0][0] in ("export", "merge")
             and tmp_curr.success is True
         ):
-            self.gui2_log = try_move_last_info(tmp_curr, self.gui2_log)
+            update_manifest(tmp_curr)
 
         self.check_reindex_pop()
         self.check_gray_outs()

--- a/src/dui/m_idials_gui.py
+++ b/src/dui/m_idials_gui.py
@@ -603,7 +603,7 @@ class MainWidget(QMainWindow):
             my_widget.activate_me(cur_nod=self.idials_runner.current_node)
 
         else:
-            if self.idials_runner.current_node.ll_command_lst[0][0] != "export":
+            if self.idials_runner.current_node.ll_command_lst[0][0] not in ("export", "merge"):
                 self.stop_run_retry.repeat_btn.setEnabled(True)
 
             my_widget.gray_me_out()
@@ -795,7 +795,7 @@ class MainWidget(QMainWindow):
             # Supress opening of the reindex popup next time
             self.just_reindexed = True
 
-        elif tmp_curr.ll_command_lst[0][0] == "export" and tmp_curr.success is True:
+        elif tmp_curr.ll_command_lst[0][0] in ("export", "merge") and tmp_curr.success is True:
             self.gui2_log = try_move_last_info(tmp_curr, self.gui2_log)
 
         self.check_reindex_pop()
@@ -857,6 +857,7 @@ class MainWidget(QMainWindow):
             "symmetry": ["refine_bravais_settings", "scale", "export"],
             "scale": ["refine_bravais_settings", "symmetry", "export"],
             "export": [None],
+            "merge": [None],
             "generate_mask": ["find_spots"],
             "modify_geometry": ["find_spots"],
             "None": [None],

--- a/src/dui/simpler_param_widgets.py
+++ b/src/dui/simpler_param_widgets.py
@@ -426,7 +426,6 @@ class IntegrateSimplerParamTab(SimpleParamTab):
         self.lst_var_widg = _get_all_direct_layout_widget_children(localLayout)
 
 
-
 class SymmetrySimplerParamTab(SimpleParamTab):
     """
     This widget is the tool for tunning the simpler and most common parameters


### PR DESCRIPTION
This is intended to fix #179 but ended up more complicated than I expected. To get merged MTZs I had to get DUI to run `dials.merge` instead of `dials.export`. DUI takes a lot of control over what commands can be run and has various bits of special case handling, not all of which I understand.

There are still some bugs in this area (like #181 and #147) but I don't think these have been _introduced_ here, just remain unfixed.